### PR TITLE
Missing call to `.rvs(10)`

### DIFF
--- a/content/machine_learning/model_selection/hyperparameter_tuning_using_grid_search.md
+++ b/content/machine_learning/model_selection/hyperparameter_tuning_using_grid_search.md
@@ -46,7 +46,7 @@ logistic = linear_model.LogisticRegression()
 penalty = ['l1', 'l2']
 
 # Create regularization hyperparameter space
-C = np.logspace(0, 4, 10)
+C = np.logspace(0, 4, 10).rvs(10)
 
 # Create hyperparameter options
 hyperparameters = dict(C=C, penalty=penalty)


### PR DESCRIPTION
on line 49 after `C = np.logspace(0, 4, 10)`