### PR TITLE
Fix markdown syntax for "grouping options" table

### DIFF
--- a/content/python/data_wrangling/pandas_group_data_by_time.md
+++ b/content/python/data_wrangling/pandas_group_data_by_time.md
@@ -276,30 +276,30 @@ df.resample('M').sum()
 
 There are many options for grouping. You can learn more about them in [Pandas's timeseries docs](http://pandas.pydata.org/pandas-docs/stable/timeseries.html), however, I have also listed them below for your convience.
 
-| Value | Description
-|---|
-|B   |    business day frequency
-|C   |    custom business day frequency (experimental)
-|D   |    calendar day frequency
-|W   |    weekly frequency
-|M   |    month end frequency
-|BM  |    business month end frequency
-|CBM |    custom business month end frequency
-|MS  |    month start frequency
-|BMS |    business month start frequency
-|CBMS|    custom business month start frequency
-|Q   |    quarter end frequency
-|BQ  |    business quarter endfrequency
-|QS  |    quarter start frequency
-|BQS |    business quarter start frequency
-|A   |    year end frequency
-|BA  |    business year end frequency
-|AS  |    year start frequency
-|BAS |    business year start frequency
-|BH  |    business hour frequency
-|H   |    hourly frequency
-|T   |    minutely frequency
-|S   |    secondly frequency
-|L   |    milliseonds
-|U   |    microseconds
-|N   |    nanosecondsa
+| Value | Description                                  |
+|-------|----------------------------------------------|
+| B     | business day frequency                       |
+| C     | custom business day frequency (experimental) |
+| D     | calendar day frequency                       |
+| W     | weekly frequency                             |
+| M     | month end frequency                          |
+| BM    | business month end frequency                 |
+| CBM   | custom business month end frequency          |
+| MS    | month start frequency                        |
+| BMS   | business month start frequency               |
+| CBMS  | custom business month start frequency        |
+| Q     | quarter end frequency                        |
+| BQ    | business quarter endfrequency                |
+| QS    | quarter start frequency                      |
+| BQS   | business quarter start frequency             |
+| A     | year end frequency                           |
+| BA    | business year end frequency                  |
+| AS    | year start frequency                         |
+| BAS   | business year start frequency                |
+| BH    | business hour frequency                      |
+| H     | hourly frequency                             |
+| T     | minutely frequency                           |
+| S     | secondly frequency                           |
+| L     | milliseonds                                  |
+| U     | microseconds                                 |
+| N     | nanosecondsa                                 |


### PR DESCRIPTION
The "Grouping Options" table wasn't using valid syntax, so it
displayed poorly on the website.