### PR TITLE
Fix typo in comments of "Handling Long Lones of code"

### DIFF
--- a/content/python/basics/handling_long_lines_of_code.ipynb
+++ b/content/python/basics/handling_long_lines_of_code.ipynb
@@ -86,7 +86,7 @@
    "outputs": [],
    "source": [
     "# Create a variable with the count of members per age\n",
-    "member_years_by_age = [# multiple the first list's element by the second list's element\n",
+    "member_years_by_age = [# multiply the first list's element by the second list's element\n",
     "                           first_list_element * second_list_element \n",
     "                           # for the first list's elements and second list's element \n",
     "                           for first_list_element, second_list_element \n",


### PR DESCRIPTION
When it says "multiple" I think you mean "multiply" 

https://chrisalbon.com/python/basics/handling_long_lines_of_code/